### PR TITLE
Execute Windows commands via Powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ Here are some suggested addtions to your bash profile.
 ## PeopleTools Support
 This has been tested using:
 * 8.55
+
+
+## Features
+
+* Supports Service Accounts or User Accounts. `psa` can run commands as a service account so domains are started under the correct account

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -103,8 +103,13 @@ def do_list
 end
 
 def do_summary
-    do_cmd("psadmin -envsummary")
-    #do_status("web","all")
+    case "#{OS_CONST}"
+    when "linux"
+        do_cmd("psadmin -envsummary")
+        #do_status("web","all")
+    when "windows"
+        do_cmd("#{ENV['PS_HOME']}/appserv/psadmin -envsummary")
+    end
 end
 
 def do_status(type, domain)

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -53,7 +53,7 @@ def do_cmd(cmd)
             end
         end
     when "windows"
-        out = `"#{cmd}"`
+        out = `powershell -command "#{cmd}"`
     else
         out = "Invalid OS"
     end
@@ -108,7 +108,7 @@ def do_summary
         do_cmd("psadmin -envsummary")
         #do_status("web","all")
     when "windows"
-        do_cmd("#{ENV['PS_HOME']}/appserv/psadmin -envsummary")
+        do_cmd("psadmin -envsummary")
     end
 end
 

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -103,13 +103,8 @@ def do_list
 end
 
 def do_summary
-    case "#{OS_CONST}"
-    when "linux"
-        do_cmd("psadmin -envsummary")
-        #do_status("web","all")
-    when "windows"
-        do_cmd("psadmin -envsummary")
-    end
+    do_cmd("psadmin -envsummary")
+    #do_status("web","all")
 end
 
 def do_status(type, domain)


### PR DESCRIPTION
* Use `powershell -command "#{cmd}"` to execute commands on Windows.