### PR TITLE
Added gsub function in find_apps, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ Here are some suggested addtions to your bash profile.
 ## PeopleTools Support
 This has been tested using:
 * 8.55
+
+
+## Features
+
+* Supports Service Accounts or User Accounts. `psa` can run commands as a service account so domains are started under the correct account

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -103,8 +103,13 @@ def do_list
 end
 
 def do_summary
-    do_cmd("psadmin -envsummary")
-    #do_status("web","all")
+    case "#{OS_CONST}"
+    when "linux"
+        do_cmd("psadmin -envsummary")
+        #do_status("web","all")
+    when "windows"
+        do_cmd("#{ENV['PS_HOME']}/appserv/psadmin -envsummary")
+    end
 end
 
 def do_status(type, domain)

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -53,7 +53,7 @@ def do_cmd(cmd)
             end
         end
     when "windows"
-        out = `"#{cmd}"`
+        out = `powershell -command "#{cmd}"`
     else
         out = "Invalid OS"
     end
@@ -108,7 +108,7 @@ def do_summary
         do_cmd("psadmin -envsummary")
         #do_status("web","all")
     when "windows"
-        do_cmd("#{ENV['PS_HOME']}/appserv/psadmin -envsummary")
+        do_cmd("psadmin -envsummary")
     end
 end
 

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -103,13 +103,8 @@ def do_list
 end
 
 def do_summary
-    case "#{OS_CONST}"
-    when "linux"
-        do_cmd("psadmin -envsummary")
-        #do_status("web","all")
-    when "windows"
-        do_cmd("psadmin -envsummary")
-    end
+    do_cmd("psadmin -envsummary")
+    #do_status("web","all")
 end
 
 def do_status(type, domain)

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -75,17 +75,17 @@ def do_cmd_banner(c,t,d)
 end
 
 def find_apps
-    apps = Dir.glob("#{ENV['PS_CFG_HOME']}/appserv/*/psappsrv.ubx")
+    apps = Dir.glob("#{ENV['PS_CFG_HOME']}".gsub('\\','/') + "/appserv/*/psappsrv.ubx")
     apps.map! {|app| app.split("/")[-2]}
 end
 
 def find_prcss
-    prcss = Dir.glob("#{ENV['PS_CFG_HOME']}/appserv/prcs/*/psprcsrv.ubx")
+    prcss = Dir.glob("#{ENV['PS_CFG_HOME']}".gsub('\\','/') + "/appserv/prcs/*/psprcsrv.ubx")
     prcss.map! {|prcs| prcs.split("/")[-2]}
 end
 
 def find_webs
-    webs = Dir.glob("#{ENV['PS_CFG_HOME']}/webserv/*/piaconfig")
+    webs = Dir.glob("#{ENV['PS_CFG_HOME']}".gsub('\\','/') + "/webserv/*/piaconfig")
     webs.map! {|web| web.split("/")[-2]}
 end
 

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -62,7 +62,7 @@ def do_cmd(cmd)
             end
         end
     when "windows"
-        out = `powershell -command "#{cmd}"`
+        out = `powershell -NoProfile -Command "#{cmd}"`
     else
         out = "Invalid OS"
     end

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -70,8 +70,8 @@ def do_cmd(cmd)
 end
 
 def do_cmd_banner(c,t,d)
-   puts ""
-   puts "### #{c} - #{t} - #{d} ###"
+    puts ""
+    puts "### #{c} - #{t} - #{d} ###"
 end
 
 def find_apps
@@ -103,7 +103,7 @@ def do_list
     puts "PS_PSA_SUDO:     #{PS_PSA_SUDO}"
     puts "PS_POOL_MGMT:    #{PS_POOL_MGMT}"
     puts "PS_HEALTH_FILE:  #{PS_HEALTH_FILE}"
-    puts "PS_HERALTH_TIME: #{PS_HEALTH_TIME}"
+    puts "PS_HEALTH_TIME:  #{PS_HEALTH_TIME}"
     puts "" 
     puts "app:"
     find_apps.each do |a|


### PR DESCRIPTION
The `glob` function doesn't work with the Windows-style path separators. Added the `gsub` function to modify the `PS_CFG_HOME` paths to work with the `find_apps`, etc methods.

Also fixed a typo in PS_HEALTH_TIME :)