### PR TITLE
Window Support for Web

### DIFF
--- a/bin/psa
+++ b/bin/psa
@@ -38,7 +38,7 @@ PS_HEALTH_FILE      = ENV['PS_HEALTH_FILE'] || "health.html"
 PS_HEALTH_TIME      = ENV['PS_HEALTH_TIME'] || "60"
 PS_PSA_SUDO         = ENV['PS_PSA_SUDO'] || "on"
 PS_PSADMIN_PATH     = "#{OS_CONST}" == "linux" ? "#{env('PS_HOME')}/bin" : "cmd /c #{env('PS_HOME')}/appserv"
-USE_WIN_SERVICES    = ENV['USE_WIN_SERVICES'] || "false"
+PS_WIN_SERVICES    = ENV['PS_WIN_SERVICES'] || "false"
 
 # validation
 # check runtime user

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -145,7 +145,7 @@ def do_list
     puts "PS_POOL_MGMT:    #{PS_POOL_MGMT}"
     puts "PS_HEALTH_FILE:  #{PS_HEALTH_FILE}"
     puts "PS_HEALTH_TIME:  #{PS_HEALTH_TIME}"
-    puts "USE_WIN_SERVICES: #{USE_WIN_SERVICES}"
+    puts "PS_WIN_SERVICES: #{PS_WIN_SERVICES}"
     puts "" 
     puts "app:"
     find_apps.each do |a|
@@ -193,14 +193,14 @@ def do_start(type, domain)
 
     case type
     when "app"
-        case "#{USE_WIN_SERVICES}"
+        case "#{PS_WIN_SERVICES}"
         when "true"
             do_cmd("start-service #{app_service_name}")
         else
             do_cmd("#{PS_PSADMIN_PATH}/psadmin -c boot -d #{domain}")
         end
     when "prcs"
-        case "#{USE_WIN_SERVICES}"
+        case "#{PS_WIN_SERVICES}"
         when "true"
             do_cmd("start-service #{prcs_service_name}")
         else
@@ -211,7 +211,7 @@ def do_start(type, domain)
         when "linux"
             do_cmd("#{PS_PSADMIN_PATH}/psadmin -w start -d #{domain}")
         when "windows"
-            case "#{USE_WIN_SERVICES}"
+            case "#{PS_WIN_SERVICES}"
             when "true"
                 do_cmd("start-service #{web_service_name}")
             else
@@ -231,14 +231,14 @@ def do_stop(type, domain)
 
     case type
     when "app"
-        case "#{USE_WIN_SERVICES}"
+        case "#{PS_WIN_SERVICES}"
         when "true"
             do_cmd("stop-service #{app_service_name}")
         else
             do_cmd("#{PS_PSADMIN_PATH}/psadmin -c shutdown -d #{domain}")
         end
     when "prcs"
-        case "#{USE_WIN_SERVICES}"
+        case "#{PS_WIN_SERVICES}"
         when "true"
             do_cmd("stop-service #{prcs_service_name}")
         else
@@ -249,7 +249,7 @@ def do_stop(type, domain)
         when "linux"
             do_cmd("${PS_CFG_HOME?}/webserv/#{domain}/bin/stopPIA.sh")
         when "windows"
-            case "#{USE_WIN_SERVICES}"
+            case "#{PS_WIN_SERVICES}"
             when "true"
                 do_cmd("stop-service #{web_service_name}")
             else


### PR DESCRIPTION
* psa start/stop web works in Windows via `psadmin`
* set `PS_WIN_SERVICES` and psadmin-plus will start/stop with Window Services. This assumes the DPK convention for the name, but that can be overridden in the configuration file. The override must contain `#{domain}` and you can use splats for wildcards.

```
WEB_SERVICE_NAME="#{domain}*-PIA"
APP_SERVICE_NAME="PeopleSoft*#{domain}"
PRCS_SERVICE_NAME="PeopleSoft*#{domain}"
```