### PR TITLE
Added basic multi-PS_CFG_HOME support. Added poolrm/pooladd back

### DIFF
--- a/bin/psa
+++ b/bin/psa
@@ -4,9 +4,10 @@ require 'psadmin_plus'
 #require_relative '../lib/psadmin_plus.rb'
 
 # options
-opts_c = ARGV.shift || "help"
-opts_t = ARGV.shift || "all"
-opts_d = ARGV.shift || "all"
+opts_c   = ARGV.shift || "help"
+opts_t   = ARGV.shift || "all"
+opts_d   = ARGV.shift || "all"
+opt_cfg  = ARGV.shift
 
 commands = opts_c.split(',')
 types = opts_t.split(',')
@@ -36,9 +37,12 @@ PS_RUNTIME_USER     = ENV['PS_RUNTIME_USER'] || "psadm2"
 PS_POOL_MGMT        = ENV['PS_POOL_MGMT'] || "on"
 PS_HEALTH_FILE      = ENV['PS_HEALTH_FILE'] || "health.html"
 PS_HEALTH_TIME      = ENV['PS_HEALTH_TIME'] || "60"
+PS_HEALTH_TEXT      = ENV['PS_HEALTH_TEXT'] || "true"
 PS_PSA_SUDO         = ENV['PS_PSA_SUDO'] || "on"
 PS_PSADMIN_PATH     = "#{OS_CONST}" == "linux" ? "#{env('PS_HOME')}/bin" : "cmd /c #{env('PS_HOME')}/appserv"
-PS_WIN_SERVICES    = ENV['PS_WIN_SERVICES'] || "false"
+PS_WIN_SERVICES     = ENV['PS_WIN_SERVICES'] || "false"
+PS_MULTI_HOME       = ENV['PS_MULTI_HOME'] || "false"
+PS_PSA_DEBUG        = ENV['PS_PSA_DEBUG']  || "false"
 
 # validation
 # check runtime user


### PR DESCRIPTION
* Support for multiple `PS_CFG_HOME`s. `psa` assumes that the domain names is also the `PS_CFG_HOME` folder name above your `PS_MULTI_HOME` path. To support this, set the environment variable `PS_MULTI_HOME` to the base config folder. E.g, 
```
$env:PS_MULTI_HOME="c:\psft\cfg"

tree $env:PS_MULTI_HOME
├───HRDEV
├───HRTST
```

* Also re-added support for LB pool management. Stopping a web domain will call `poolrm` first; starting a web domain will call `pooladd` after the domain starts.