### PR TITLE
Add reconfigure option (aka 'bounce light')

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 ## Example Usage
 
-| Task                  | Command              |
-| --------------------- | -------------------- |
-| help                  | `psa help`           |
-| list domains          | `psa list`           |
-| start all domains     | `psa start`          |
-| start all web domains | `psa start web`      |
-| start hdev web domain | `psa start web hdev` |
+| Task                          | Command                |
+| ----------------------------- | ---------------------- |
+| help                          | `psa help`             |
+| list domains                  | `psa list`             |
+| start all domains             | `psa start`            |
+| start all web domains         | `psa start web`        |
+| start hdev web domain         | `psa start web hdev`   |
+| clear hrdev cache and restart | `psa bounce app hrdev` |
 
 ## Setup
 

--- a/bin/psa
+++ b/bin/psa
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'psadmin_plus'
-#require_relative '../lib/psadmin_plus.rb'
 
 # options
 opts_c   = ARGV.shift || "help"
@@ -99,6 +98,9 @@ commands.each do |c|
                 when "configure"
                     do_cmd_banner(c,t,d)
                     do_configure(t,d)
+                when "reconfigure"
+                    do_cmd_banner(c,t,d)
+                    do_reconfigure(t,d)
                 when "purge"
                     do_cmd_banner(c,t,d)
                     do_purge(t,d)

--- a/lib/psadmin_plus.rb
+++ b/lib/psadmin_plus.rb
@@ -18,6 +18,7 @@ def do_help
     puts "    stop           poolrm, if enabled, stop the domain"
     puts "    restart        stop and start the domain"
     puts "    purge          clear domain cache"
+    puts "    reconfigure    stop, configure, and start the domain"
     puts "    bounce         stop, flush, purge, configure and start the domain"
     puts "    kill           force stop the domain"
     puts "    configure      configure the domain"
@@ -467,6 +468,12 @@ end
 
 def do_restart(type, domain)
     do_stop(type, domain)
+    do_start(type, domain)
+end
+
+def do_reconfigure(type, domain)
+    do_stop(type, domain)
+    do_configure(type, domain)
     do_start(type, domain)
 end
 

--- a/psadmin_plus.gemspec
+++ b/psadmin_plus.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
     s.name        = 'psadmin_plus'
-    s.version     = '2.0.3'
-    s.date        = '2020-10-13'
+    s.version     = '2.0.4'
+    s.date        = '2021-01-04'
     s.summary     = "psadmin plus"
     s.description = "A psadmin helper tool"
     s.authors     = ["Kyle Benson", "Dan Iverson"]


### PR DESCRIPTION
Adding a `reconfigure` option that does:

1. stop domain
2. configure domain
3. start domain

This is useful when you need to reload the domain configuration but don't need to clear cache on the Tuxedo domains.